### PR TITLE
Add cache-manager and use Lambda specific settings for caching

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,15 +2,23 @@ const { Application } = require('probot')
 const { resolve } = require('probot/lib/resolver')
 const { findPrivateKey } = require('probot/lib/private-key')
 const { template } = require('./views/probot')
+const cacheManager = require('cache-manager')
 
 let app
 let probot
+let cache
 
 const loadProbot = (plugin) => {
+  cache = cache || cacheManager.caching({
+    store: 'memory',
+    ttl: 60 * 60 // 1 hour
+  })
+
   app = app || new Application({
     id: process.env.APP_ID,
     secret: process.env.WEBHOOK_SECRET,
-    cert: findPrivateKey()
+    cert: findPrivateKey(),
+    cache
   })
 
   if (typeof plugin === 'string') {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ let cache
 const loadProbot = (plugin) => {
   cache = cache || cacheManager.caching({
     store: 'memory',
-    ttl: 60 * 60 // 1 hour
+    ttl: 60 * 5 // 5 minutes
   })
 
   app = app || new Application({


### PR DESCRIPTION
Fixes #3 

This adds cache-manager to the plugin and sets the cache to values that don't assume a long running container.

/cc @bdougie