### PR TITLE
named export instead of default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ $ npm install @probot/serverless-lambda
 ```
 
 ```javascript
-# handler.js
+// handler.js
 const { serverless } = require('@probot/serverless-lambda')
 const appFn = require('./')
 module.exports.probot = serverless(appFn)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ $ npm install @probot/serverless-lambda
 
 ```javascript
 # handler.js
-const serverless = require('@probot/serverless-lambda')
+const { serverless } = require('@probot/serverless-lambda')
 const appFn = require('./')
 module.exports.probot = serverless(appFn)
 ```


### PR DESCRIPTION
[Here](https://github.com/probot/serverless-lambda/blob/master/index.js#L24) `serverless` is a named export

so it should be used like 

```js
const { serverless } = require('@probot/serverless-lambda')
```
-----
[View rendered README.md](https://github.com/itaditya/serverless-lambda/blob/patch-1/README.md)