### PR TITLE
Fix deprecated property in Probot

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports.serverless = appFn => {
     if (event) {
       try {
         await probot.receive({
-          event: e,
+          name: e,
           payload: event.body
         })
         const res = {


### PR DESCRIPTION
Error: Propery `event` is deprecated, use `name`