### PR TITLE
fix: remove undocumented legacy callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports.serverless = appFn => {
         },
         body: template
       }
-      return context.done(null, res)
+      return res
     }
 
     // Otherwise let's listen handle the payload
@@ -66,21 +66,21 @@ module.exports.serverless = appFn => {
             message: `Received ${e}.${event.body.action}`
           })
         }
-        return context.done(null, res)
+        return res
       } catch (err) {
         console.error(err)
-        return context.done(null, {
+        return {
           statusCode: 500,
           body: JSON.stringify(err)
-        })
+        }
       }
     } else {
       console.error({ event, context })
-      context.done(null, 'unknown error')
+      throw 'unknown error'
     }
-    return context.done(null, {
+    return {
       statusCode: 200,
       body: 'Nothing to do.'
-    })
+    }
   }
 }


### PR DESCRIPTION
`context.done` is from the pre-node4.10 runtime days of lambda, it was deprecated in favor of callback, which is optionally sidelined in favor of an async/promise-based return. If the function receives no callback and returns a promise or is marked as async, you should simply return/throw in order to actuate the callbacks.

[Proof that it's no longer even in the documentation](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-context.html)
[See the note above the typings](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/aws-lambda/index.d.ts#L448)

While they do technically work... I think relying on them is a bad idea. 