### PR TITLE
Use the new probot package @probot/get-private-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,21 @@ module.exports.probot = serverless(appFn);
 
 This package moves the functionality of `probot run` into a handler suitable for usage on AWS Lambda + API Gateway. Follow the documentation on [Environment Configuration](https://probot.github.io/docs/configuration/) to setup your app's environment variables. You can add these to `.env`, but for security reasons you may want to use the [AWS CLI](https://aws.amazon.com/cli/) or [Serverless Framework](https://github.com/serverless/serverless) to set Environment Variables for the function so you don't have to include any secrets in the deployed package.
 
+To use `.env` files with the [Serverless Framework](https://github.com/serverless/serverless), you can install the [serverless-dotenv-plugin](https://www.serverless.com/plugins/serverless-dotenv-plugin). This will take care of keeping your secrets out of your deployed package.
+
+### Serverless dotenv plugin usage
+```yaml
+plugins:
+  - serverless-dotenv-plugin # Load .env as environment variables
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+```
+
 For the private key, since AWS environment variables cannot be multiline strings, you could [Base64 encode](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings) the `.pem` file you get from the GitHub App or use [KMS](https://aws.amazon.com/kms/) to encrypt and store the key.
+
+
 
 ## Differences from `probot run`
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const { Probot } = require("probot");
 const { resolve } = require("probot/lib/helpers/resolve-app-function");
-const { findPrivateKey } = require("probot/lib/helpers/get-private-key");
+const { getPrivateKey } = require("@probot/get-private-key");
 const { template } = require("./views/probot");
 
 let probot;
@@ -11,7 +11,7 @@ const loadProbot = (appFn) => {
     new Probot({
       id: process.env.APP_ID,
       secret: process.env.WEBHOOK_SECRET,
-      privateKey: findPrivateKey(),
+      privateKey: getPrivateKey(),
     });
 
   if (typeof appFn === "string") {


### PR DESCRIPTION
Prior to this change, errors would occur when trying to access the old helper file. Probot no longer includes this helper file.

This change adds the new package to make it compatible with the latest version of Probot.

Also updates README with more information on setting this up with environment variables.


-----
[View rendered README.md](https://github.com/KinnersleyM/serverless-lambda/blob/kinnersleym/fix-get-private-key/README.md)